### PR TITLE
Refines parcel status and locker logic

### DIFF
--- a/ParcelBox.Api/Controllers/ParcelsController.cs
+++ b/ParcelBox.Api/Controllers/ParcelsController.cs
@@ -168,7 +168,13 @@ public class ParcelsController(AppDbContext dbContext) : BaseController
                 return BadRequest($"Invalid parcel status value: '{parcelDto.ParcelStatus}'.");
             }
 
+            if (status == Status.Send)
+            {
+                return BadRequest("New parcel status can't be send!");
+            }
+
             existingParcel.ParcelStatus = status;
+            await ParcelService.ChangeLockerBoxStatusAsync(dbContext, existingParcel.InitialLockerBoxId, true);
             dbContext.Entry(existingParcel).State = EntityState.Modified;
         }
         

--- a/ParcelBox.Api/Validation/ParcelsValidation/EditParcelDtoValidator.cs
+++ b/ParcelBox.Api/Validation/ParcelsValidation/EditParcelDtoValidator.cs
@@ -11,6 +11,6 @@ public class EditParcelDtoValidator : AbstractValidator<EditParcelDto>
         RuleFor(x => x.ParcelStatus)
             .NotEmpty()
             .IsEnumName(typeof(Status), caseSensitive: false)
-            .WithMessage("Status given was invalid. Valid statues: (Small, Medium, Big)");
+            .WithMessage("Status given was invalid. Valid statues: (OnItsWay, Delivered, Received)");
     }
 }


### PR DESCRIPTION
Prevents direct update of a parcel's status to 'Send', enforcing a valid parcel lifecycle.
Automatically updates the associated locker box status when a parcel's status is changed, ensuring data consistency between parcels and their initial locker locations.